### PR TITLE
updates mix.exs with the newest version of alice_google_images

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule ActiveAlice.Mixfile do
        {:websocket_client, github: "jeremyong/websocket_client"},
        # {:alice, path: "~/projects/alice/alice"}
        {:alice,                  "~> 0.2.3"},
-       {:alice_google_images,    "~> 0.1.0"},
+       {:alice_google_images,    "~> 0.1.1"},
        {:alice_karma,            "~> 0.1.0"},
        {:alice_shizzle,          "~> 0.1.0"}
      ]


### PR DESCRIPTION
recommended to be merged after the new this [PR](https://github.com/alice-bot/alice_google_images/pull/1) is merged and hex.pm updated
